### PR TITLE
Always provide simd_mask cast overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ implementation unconditionally. This is useful for testing.
 
 ## Additional Features
 
+The TS curiously forgot to add `simd_cast` and `static_simd_cast` overloads for 
+`simd_mask`. With `vir::stdx::(static_)simd_cast`, casts will also work for 
+`simd_mask`. This does not require any additional includes.
 
 ### Bitwise operators for floating-point `simd`:
 

--- a/vir/simd.h
+++ b/vir/simd.h
@@ -19,6 +19,7 @@
 namespace vir::stdx
 {
   using namespace std::experimental::parallelism_v2;
+  using namespace std::experimental::parallelism_v2::__proposed;
 }
 
 #else


### PR DESCRIPTION
ChangeLog:

	* README.md: Document simd_cast for simd_mask.
	* vir/simd.h: Import parallelism_v2::__proposed from libstdc++.