### PR TITLE
Add vir::simd_permute following P2664

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,62 @@ Note that `vir::cvt` also works for `simd_mask` and non-`simd` types. Thus,
 (i.e. well-formed for `T` and `simd<T>`).
 
 
+### Permutations ([paper](https://wg21.link/P2664)):
+
+*Requires Concepts (C++20).*
+
+```c++
+#include <vir/simd_permute.h>
+
+// v = {0, 1, 2, 3} -> {1, 0, 3, 2}
+vir::simd_permute(v, vir::simd_permutations::swap_neighbors);
+
+// v = {1, 2, 3, 4} -> {2, 2, 2, 2}
+vir::simd_permute(v, [](unsigned) { return 1; });
+
+// v = {1, 2, 3, 4} -> {3, 3, 3, 3}
+vir::simd_permute(v, [](unsigned) { return -2; });
+```
+
+The following permutations are pre-defined:
+
+* `vir::simd_permutations::duplicate_even`: copy values at even indices to 
+  neighboring odd position
+
+* `vir::simd_permutations::duplicate_odd`: copy values at odd indices to 
+  neighboring even position
+
+* `vir::simd_permutations::swap_neighbors<N>`: swap `N` consecutive values with 
+the following `N` consecutive values
+
+* `vir::simd_permutations::broadcast<Idx>`: copy the value at index `Idx` to 
+all other values
+
+* `vir::simd_permutations::broadcast_first`: alias for `broadcast<0>`
+
+* `vir::simd_permutations::broadcast_last`: alias for `broadcast<-1>`
+
+* `vir::simd_permutations::reverse`: reverse the order of all values
+
+* `vir::simd_permutations::rotate<Offset>`: positive `Offset` rotates values to 
+  the left, negative `Offset` rotates values to the right (moves values from 
+  index `(i + Offset) % size` to `i`)
+
+* `vir::simd_permutations::shift<Offset>`: positive `Offset` shifts values to 
+  the left, negative `Offset` shifts values to the right; shifting in zeros.
+
+A `vir::simd_permute(x, idx_perm)` overload, where `x` is of *vectorizable* 
+type, is also included, facilitating generic code.
+
+A special permutation `vir::simd_shift_in<N>(x, ...)` shifts by N elements 
+shifting in elements from additional `simd` objects passed via the pack. 
+Example:
+```c++
+// v = {1, 2, 3, 4}, w = {5, 6, 7, 8} -> {2, 3, 4, 5}
+vir::simd_shift_in<1>(v, w);
+```
+
+
 ### Bitwise operators for floating-point `simd`:
 
 ```c++

--- a/vir/simd.h
+++ b/vir/simd.h
@@ -513,24 +513,26 @@ namespace vir::stdx
 
       // load constructor
       template <typename Flags>
+        constexpr
         simd_mask(const value_type* mem, Flags)
         : data(mem[0])
         {}
 
       template <typename Flags>
+        constexpr
         simd_mask(const value_type* mem, simd_mask k, Flags)
         : data(k ? mem[0] : false)
         {}
 
       // loads [simd_mask.load]
       template <typename Flags>
-        void
+        constexpr void
         copy_from(const value_type* mem, Flags)
         { data = mem[0]; }
 
       // stores [simd_mask.store]
       template <typename Flags>
-        void
+        constexpr void
         copy_to(value_type* mem, Flags) const
         { mem[0] = data; }
 
@@ -1429,13 +1431,14 @@ namespace vir::stdx
 
       // load constructor
       template <typename U, typename Flags>
+        constexpr
         simd(const U* mem, Flags)
         : simd([mem](auto i) -> value_type { return mem[i]; })
         {}
 
       // loads [simd.load]
       template <typename U, typename Flags>
-        void
+        constexpr void
         copy_from(const detail::Vectorizable<U>* mem, Flags)
         {
           for (int i = 0; i < N; ++i)
@@ -1444,7 +1447,7 @@ namespace vir::stdx
 
       // stores [simd.store]
       template <typename U, typename Flags>
-        void
+        constexpr void
         copy_to(detail::Vectorizable<U>* mem, Flags) const
         {
           for (int i = 0; i < N; ++i)

--- a/vir/simd_concepts.h
+++ b/vir/simd_concepts.h
@@ -10,6 +10,8 @@
 #define VIR_HAVE_SIMD_CONCEPTS 1
 #include <concepts>
 
+#include "simd.h"
+
 namespace vir
 {
   using std::size_t;
@@ -32,6 +34,9 @@ namespace vir
     concept any_simd_mask
       = stdx::is_simd_mask_v<V> and any_simd<typename V::simd_type>
 	  and simd_abi_tag<typename V::abi_type>;
+
+  template <typename V>
+    concept any_simd_or_mask = any_simd<V> or any_simd_mask<V>;
 
   template <typename V, typename T>
     concept typed_simd = any_simd<V> and std::same_as<T, typename V::value_type>;

--- a/vir/simd_permute.h
+++ b/vir/simd_permute.h
@@ -1,0 +1,229 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright © 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH
+ *                  Matthias Kretz <m.kretz@gsi.de>
+ */
+
+// Implements non-members of P2664
+
+#ifndef VIR_SIMD_PERMUTE_H_
+#define VIR_SIMD_PERMUTE_H_
+
+#include "simd_concepts.h"
+
+#if VIR_HAVE_SIMD_CONCEPTS
+#define VIR_HAVE_SIMD_PERMUTE 1
+
+#include "simd.h"
+#include <bit>
+
+namespace vir
+{
+  namespace detail
+  {
+    template <typename F>
+      concept index_permutation_function_nosize = requires(F const& f)
+      {
+	{ f(std::integral_constant<std::size_t, 0>()) } -> std::integral;
+      };
+
+    template <typename F, std::size_t Size>
+      concept index_permutation_function_size = requires(F const& f)
+      {
+	{ f(std::integral_constant<std::size_t, 0>(), std::integral_constant<std::size_t, Size>()) }
+	  -> std::integral;
+      };
+
+    template <typename F, std::size_t Size>
+      concept index_permutation_function
+	= index_permutation_function_size<F, Size> or index_permutation_function_nosize<F>;
+  }
+
+  constexpr int simd_permute_zero = std::numeric_limits<int>::max();
+
+  constexpr int simd_permute_uninit = simd_permute_zero - 1;
+
+  namespace simd_permutations
+  {
+    struct DuplicateEven
+    {
+      consteval unsigned
+      operator()(unsigned i) const
+      { return i & ~1u; }
+    };
+
+    inline constexpr DuplicateEven duplicate_even {};
+
+    struct DuplicateOdd
+    {
+      consteval unsigned
+      operator()(unsigned i) const
+      { return i | 1u; }
+    };
+
+    inline constexpr DuplicateOdd duplicate_odd {};
+
+    template <unsigned N>
+      struct SwapNeighbors
+      {
+	consteval unsigned
+	operator()(unsigned i, auto size) const
+	{
+	  static_assert(size % (2 * N) == 0,
+			"swap_neighbors<N> permutation requires a multiple of 2N elements");
+	  if (std::has_single_bit(N))
+	    return i ^ N;
+	  else if (i % (2 * N) >= N)
+	    return i - N;
+	  else
+	    return i + N;
+	}
+      };
+
+    template <unsigned N = 1u>
+      inline constexpr SwapNeighbors<N> swap_neighbors {};
+
+    template <int Position>
+      struct Broadcast
+      {
+	consteval int
+	operator()(int) const
+	{ return Position; }
+      };
+
+    template <int Position>
+      inline constexpr Broadcast<Position> broadcast {};
+
+    inline constexpr Broadcast<0> broadcast_first {};
+
+    inline constexpr Broadcast<-1> broadcast_last {};
+
+    struct Reverse
+    {
+      consteval int
+      operator()(int i) const
+      { return -1 - i; }
+    };
+
+    inline constexpr Reverse reverse {};
+
+    template <int Offset>
+      struct Rotate
+      {
+	consteval int
+	operator()(int i, auto size) const
+	{ return (i + Offset) % size(); }
+      };
+
+    template <int Offset>
+      inline constexpr Rotate<Offset> rotate {};
+
+    template <int Offset>
+      struct Shift
+      {
+	consteval int
+	operator()(int i, int size) const
+	{
+	  const int j = i + Offset;
+	  if constexpr (Offset >= 0)
+	    return j >= size ? simd_permute_zero : j;
+	  else
+	    return j < 0 ? simd_permute_zero : j;
+	}
+      };
+
+    template <int Offset>
+      inline constexpr Shift<Offset> shift {};
+  }
+
+  template <std::size_t N = 0, vir::any_simd_or_mask V,
+	    detail::index_permutation_function<V::size()> F>
+    VIR_ALWAYS_INLINE constexpr stdx::resize_simd_t<N == 0 ? V::size() : N, V>
+    simd_permute(V const& v, F const idx_perm) noexcept
+    {
+      using T = typename V::value_type;
+      using R = stdx::resize_simd_t<N == 0 ? V::size() : N, V>;
+      return R([&](auto i) -> T {
+	       constexpr int j = [&] {
+		 if constexpr (detail::index_permutation_function_nosize<F>)
+		   return idx_perm(i);
+		 else
+		   return idx_perm(i, std::integral_constant<std::size_t, V::size()>());
+	       }();
+	       if constexpr (j == simd_permute_zero)
+		 return 0;
+	       else if constexpr (j == simd_permute_uninit)
+		 {
+		   T uninit;
+		   return uninit;
+		 }
+	       else if constexpr (j < 0)
+		 {
+		   static_assert(-j <= int(V::size()));
+		   return v[v.size() + j];
+		 }
+	       else
+		 {
+		   static_assert(j < int(V::size()));
+		   return v[j];
+		 }
+	     });
+    }
+
+  template <std::size_t N = 0, vir::vectorizable T, detail::index_permutation_function<1> F>
+    VIR_ALWAYS_INLINE constexpr
+    std::conditional_t<N <= 1, T, stdx::resize_simd_t<N == 0 ? 1 : N, stdx::simd<T>>>
+    simd_permute(T const& v, F const idx_perm) noexcept
+    {
+      if constexpr (N <= 1)
+	{
+	  constexpr std::integral_constant<std::size_t, 0> i;
+	  constexpr int j = [&] {
+	    if constexpr (detail::index_permutation_function_nosize<F>)
+	      return idx_perm(i);
+	    else
+	      return idx_perm(i, std::integral_constant<std::size_t, 1>());
+	  }();
+	  if constexpr (j == simd_permute_zero)
+	    return 0;
+	  else if constexpr (j == simd_permute_uninit)
+	    {
+	      T uninit;
+	      return uninit;
+	    }
+	  else
+	    {
+	      static_assert(j == 0 or j == -1);
+	      return v;
+	    }
+	}
+      else
+	return simd_permute<N>(stdx::simd<T, stdx::simd_abi::scalar>(v), idx_perm);
+    }
+
+  template <int Offset, vir::any_simd_or_mask V>
+    VIR_ALWAYS_INLINE constexpr V
+    simd_shift_in(V const& a, std::convertible_to<V> auto const&... more) noexcept
+    {
+      return V([&](auto i) -> typename V::value_type {
+	       constexpr int ninputs = 1 + sizeof...(more);
+	       constexpr int w = V::size();
+	       constexpr int j = Offset + int(i);
+	       if constexpr (j >= w * ninputs)
+		 return 0;
+	       else if constexpr (j >= 0)
+		 {
+		   const V tmp[] = {a, more...};
+		   return tmp[j / w][j % w];
+		 }
+	       else if constexpr (j < -w)
+		 return 0;
+	       else
+		 return a[w + j];
+      });
+    }
+}
+
+#endif // has concepts
+#endif // VIR_SIMD_PERMUTE_H_
+
+// vim: noet cc=101 tw=100 sw=2 ts=8


### PR DESCRIPTION
ChangeLog:

	* README.md: Document simd_permute.
	* vir/simd.h (load & stores): Make constexpr.
	* vir/simd_concepts.h (any_simd_or_mask): New.
	* vir/simd_permute.h: New file.
	* vir/test.cpp (make_simd): New. Add simd_permute tests.