### PR TITLE
SIMD execution policy for standard algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 CXXFLAGS+=-Wno-attributes -Wno-unknown-pragmas
+ifneq ($(findstring GCC,$(shell $(CXX) --version)),)
+	CXXFLAGS+=-static-libstdc++
+endif
 CXXFLAGS+=-I$(PWD)
 prefix=/usr/local
 includedir=$(prefix)/include
@@ -8,11 +11,15 @@ testdir=testsuite/build
 sim=
 testflags=-march=native -std=c++2a
 
-check: check-extensions $(srcdir)/testsuite/generate_makefile.sh
-	@rm -f .simd.summary
-	$(CXX) --version
+check: check-extensions testsuite
+
+$(testdir)/Makefile: $(srcdir)/testsuite/generate_makefile.sh
 	@echo "Generating simd testsuite subdirs and Makefiles ..."
 	@$(srcdir)/testsuite/generate_makefile.sh --destination="$(testdir)" --sim="$(sim)" --testflags="$(testflags)" $(CXX) $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
+       
+testsuite: $(testdir)/Makefile
+	@rm -f .simd.summary
+	$(CXX) --version
 	@$(MAKE) -C "$(testdir)"
 	@tail -n20 $(testdir)/simd_testsuite.sum | grep -A20 -B1 'Summary ===' >> .simd.summary
 	@cat .simd.summary && rm .simd.summary
@@ -30,15 +37,20 @@ check-extensions-stdlib:
 check-extensions-fallback:
 	$(CXX) -O2 -std=gnu++2a -Wall -Wextra $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -S vir/test.cpp -o test.S
 
+run-%:
+	@$(MAKE) -C "$(testdir)" run-$*
+
 clean:
 	@rm -r "$(testdir)"
 
-help:
+help: $(testdir)/Makefile
 	@echo "... check"
+	@echo "... testsuite"
 	@echo "... check-extensions"
 	@echo "... check-extensions-stdlib"
 	@echo "... check-extensions-fallback"
 	@echo "... clean"
 	@echo "... install (using prefix=$(prefix))"
+	@$(MAKE) -C "$(testdir)" help
 
-.PHONY: check install check-extensions check-extensions-stdlib check-extensions-fallback clean help
+.PHONY: check install check-extensions check-extensions-stdlib check-extensions-fallback clean help testsuite

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ testflags=-march=native
 
 check: check-extensions testsuite-O2 testsuite-Os
 
-testsuite/build-%/Makefile: $(srcdir)/testsuite/generate_makefile.sh
+testsuite/build-%/Makefile: $(srcdir)/testsuite/generate_makefile.sh Makefile
+	@rm -f $@
 	@echo "Generating simd testsuite ($*) subdirs and Makefiles ..."
 	@$(srcdir)/testsuite/generate_makefile.sh --destination="testsuite/build-$*" --sim="$(sim)" --testflags="$(testflags)" $(CXX) -$* -std=c++2a $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
 
@@ -44,11 +45,11 @@ check-extensions-stdlib:
 check-extensions-fallback:
 	$(CXX) -O2 -std=gnu++2a -Wall -Wextra $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -S vir/test.cpp -o test.S
 
-run-%:
+run-%: $(testdir)/Makefile
 	@$(MAKE) -C "$(testdir)" run-$*
 
-run-Os-%:
-	@$(MAKE) -C "testsuite/build-Os" run-$*
+run-Os-%: $(testdirOs)/Makefile
+	@$(MAKE) -C "$(testdirOs)" run-$*
 
 run-ext-%: $(testdirext)/Makefile
 	@$(MAKE) -C "$(testdirext)" run-$*

--- a/Makefile
+++ b/Makefile
@@ -7,29 +7,27 @@ prefix=/usr/local
 includedir=$(prefix)/include
 
 srcdir=.
-testdir=testsuite/build
+testdir=testsuite/build-O2
 sim=
 testflags=-march=native -std=c++2a
 
-check: check-extensions testsuite
+check: check-extensions testsuite-O2 testsuite-Os
 
-$(testdir)/Makefile: $(srcdir)/testsuite/generate_makefile.sh
-	@echo "Generating simd testsuite subdirs and Makefiles ..."
-	@$(srcdir)/testsuite/generate_makefile.sh --destination="$(testdir)" --sim="$(sim)" --testflags="$(testflags)" $(CXX) $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
+testsuite/build-%/Makefile: $(srcdir)/testsuite/generate_makefile.sh
+	@echo "Generating simd testsuite ($*) subdirs and Makefiles ..."
+	@$(srcdir)/testsuite/generate_makefile.sh --destination="testsuite/build-$*" --sim="$(sim)" --testflags="$(testflags)" $(CXX) -O2 -$* $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
        
-testsuite: $(testdir)/Makefile
-	@rm -f .simd.summary
-	$(CXX) --version
-	@$(MAKE) -C "$(testdir)"
-	@tail -n20 $(testdir)/simd_testsuite.sum | grep -A20 -B1 'Summary ===' >> .simd.summary
-	@cat .simd.summary && rm .simd.summary
+testsuite-%: testsuite/build-%/Makefile
+	@rm -f testsuite/build-$*/.simd.summary
+	@$(MAKE) -C "testsuite/build-$*"
+	@tail -n20 testsuite/build-$*/simd_testsuite.sum | grep -A20 -B1 'Summary ===' >> testsuite/build-$*/.simd.summary
+	@cat testsuite/build-$*/.simd.summary && rm testsuite/build-$*/.simd.summary
 
 install:
 	install -d $(includedir)/vir
 	install -m 644 -t $(includedir)/vir vir/*.h
 
 check-extensions: check-extensions-stdlib check-extensions-fallback
-
 
 check-extensions-stdlib:
 	$(CXX) -O2 -std=gnu++2a -Wall -Wextra $(CXXFLAGS) -S vir/test.cpp -o test.S
@@ -40,17 +38,22 @@ check-extensions-fallback:
 run-%:
 	@$(MAKE) -C "$(testdir)" run-$*
 
-clean:
-	@rm -r "$(testdir)"
+run-Os-%:
+	@$(MAKE) -C "testsuite/build-Os" run-$*
 
-help: $(testdir)/Makefile
+clean:
+	@rm -rf testsuite/build-*
+
+help: $(testdir)/Makefile testsuite/build-Os/Makefile
 	@echo "... check"
-	@echo "... testsuite"
+	@echo "... testsuite-O2"
+	@echo "... testsuite-Os"
 	@echo "... check-extensions"
 	@echo "... check-extensions-stdlib"
 	@echo "... check-extensions-fallback"
 	@echo "... clean"
 	@echo "... install (using prefix=$(prefix))"
 	@$(MAKE) -C "$(testdir)" help
+	@$(MAKE) -C "$(testdir)" help|sed 's/run-/run-Os-/g'
 
 .PHONY: check install check-extensions check-extensions-stdlib check-extensions-fallback clean help testsuite

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,24 @@ includedir=$(prefix)/include
 
 srcdir=.
 testdir=testsuite/build-O2
+testdirOs=testsuite/build-Os
+testdirext=testsuite/build-ext
 sim=
-testflags=-march=native -std=c++2a
+testflags=-march=native
 
 check: check-extensions testsuite-O2 testsuite-Os
 
 testsuite/build-%/Makefile: $(srcdir)/testsuite/generate_makefile.sh
 	@echo "Generating simd testsuite ($*) subdirs and Makefiles ..."
-	@$(srcdir)/testsuite/generate_makefile.sh --destination="testsuite/build-$*" --sim="$(sim)" --testflags="$(testflags)" $(CXX) -O2 -$* $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
-       
+	@$(srcdir)/testsuite/generate_makefile.sh --destination="testsuite/build-$*" --sim="$(sim)" --testflags="$(testflags)" $(CXX) -$* -std=c++2a $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -DVIR_SIMD_TS_DROPIN
+
+$(testdirext)/Makefile: $(srcdir)/testsuite/generate_makefile.sh Makefile
+	@rm -f $@
+	@echo "Generating simd testsuite subdirs and Makefiles ..."
+	@mkdir -p $(testdirext)
+	@echo for_each.cc > $(testdirext)/testsuite_files_simd
+	@cd $(testdirext) && ../generate_makefile.sh --destination="." --sim="$(sim)" --testflags="-O2 $(testflags)" $(CXX) -std=gnu++2a $(CXXFLAGS) -DVIR_SIMD_TS_DROPIN
+
 testsuite-%: testsuite/build-%/Makefile
 	@rm -f testsuite/build-$*/.simd.summary
 	@$(MAKE) -C "testsuite/build-$*"
@@ -41,19 +50,24 @@ run-%:
 run-Os-%:
 	@$(MAKE) -C "testsuite/build-Os" run-$*
 
+run-ext-%: $(testdirext)/Makefile
+	@$(MAKE) -C "$(testdirext)" run-$*
+
 clean:
 	@rm -rf testsuite/build-*
 
-help: $(testdir)/Makefile testsuite/build-Os/Makefile
+help: $(testdir)/Makefile $(testdirOs)/Makefile $(testdirext)/Makefile
 	@echo "... check"
 	@echo "... testsuite-O2"
 	@echo "... testsuite-Os"
+	@echo "... testsuite-ext"
 	@echo "... check-extensions"
 	@echo "... check-extensions-stdlib"
 	@echo "... check-extensions-fallback"
 	@echo "... clean"
 	@echo "... install (using prefix=$(prefix))"
 	@$(MAKE) -C "$(testdir)" help
-	@$(MAKE) -C "$(testdir)" help|sed 's/run-/run-Os-/g'
+	@$(MAKE) -C "$(testdirOs)" help|sed 's/run-/run-Os-/g'
+	@$(MAKE) -C "$(testdirext)" help|sed 's/run-/run-ext-/g'
 
 .PHONY: check install check-extensions check-extensions-stdlib check-extensions-fallback clean help testsuite

--- a/README.md
+++ b/README.md
@@ -175,6 +175,36 @@ vir::simd_shift_in<1>(v, w);
 
 *Requires Concepts (C++20).*
 
+Use the execution policy `vir::execution::simd` with the algorithms in `vir` 
+namespace, using either the `std` or `vir` namespace. Example:
+
+```c++
+#include <vir/simd_execution.h>
+
+void increment_all(std::vector<float> data) {
+  std::for_each(vir::execution::simd, data.begin(), data.end(),
+    [](auto& v) {
+      v += 1.f;
+    });
+}
+
+// or
+
+void increment_all(std::vector<float> data) {
+  vir::for_each(vir::execution::simd, data,
+    [](auto& v) {
+      v += 1.f;
+    });
+}
+```
+
+At this point, the implementation of the execution policy requires contiguous 
+ranges / iterators.
+
+The following algorithms are currently implemented:
+
+* `std::for_each`
+* `std::count_if`
 
 ### Bitwise operators for floating-point `simd`:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Example:
 vir::simd_shift_in<1>(v, w);
 ```
 
+### SIMD execution policy ([P0350](https://wg21.link/P0350)):
+
+*Requires Concepts (C++20).*
+
 
 ### Bitwise operators for floating-point `simd`:
 

--- a/testsuite/generate_makefile.sh
+++ b/testsuite/generate_makefile.sh
@@ -96,6 +96,10 @@ cat >> "$pch" <<EOF
 #include "${srcdir}/bits/test_values.h"
 #include "${srcdir}/bits/ulp.h"
 #include "${srcdir}/bits/conversions.h"
+#include <vir/simd_iota.h>
+#include <vir/simd_execution.h>
+#include <numeric>
+#include <vector>
 #endif  // SIMD_PCH_
 EOF
 

--- a/testsuite/tests/for_each.cc
+++ b/testsuite/tests/for_each.cc
@@ -3,7 +3,6 @@
 
 #include <numeric>
 #include <vector>
-#include <execution>
 
 #include <vir/simd_iota.h>
 #include <vir/simd_execution.h>
@@ -26,19 +25,21 @@ template <typename V>
                     COMPARE(v, vir::iota_v<decltype(v)> + i);
                     i += v.size();
                   });
+    COMPARE(i, T(data.size()));
+
+    i = 1;
+    vir::for_each(exec_simd.prefer_aligned(), data.begin() + 1, data.end(),
+                  [&i](auto v) {
+                    COMPARE(v, vir::iota_v<decltype(v)> + i);
+                    i += v.size();
+                  });
+    COMPARE(i, T(data.size()));
 
     i = 0;
     std::for_each(exec_simd, data.begin(), data.end(),
                   [&i](auto v) {
                     COMPARE(v, vir::iota_v<decltype(v)> + i);
                     i += v.size();
-                  });
-
-    i = 0;
-    std::for_each(std::execution::unseq, data.begin(), data.end(),
-                  [&i](auto v) {
-                    COMPARE(v, i);
-                    i += 1;
                   });
 
     int count = vir::count_if(exec_simd, data, [](auto v) {

--- a/testsuite/tests/for_each.cc
+++ b/testsuite/tests/for_each.cc
@@ -3,6 +3,7 @@
 
 #include <numeric>
 #include <vector>
+#include <execution>
 
 #include <vir/simd_iota.h>
 #include <vir/simd_execution.h>
@@ -17,19 +18,43 @@ template <typename V>
     data.resize(V::size() * 16 - 1);
     std::iota(data.begin(), data.end(), T());
 
+    constexpr auto exec_simd = vir::execution::simd.prefer_size<V::size()>();
+
     T i = 0;
+    vir::for_each(exec_simd, data,
+                  [&i](auto v) {
+                    COMPARE(v, vir::iota_v<decltype(v)> + i);
+                    i += v.size();
+                  });
 
-    vir::for_each(vir::execution::simd, data, [&i](auto v) {
-      COMPARE(v, vir::iota_v<decltype(v)> + i);
-      i += v.size();
-    });
+    i = 0;
+    std::for_each(exec_simd, data.begin(), data.end(),
+                  [&i](auto v) {
+                    COMPARE(v, vir::iota_v<decltype(v)> + i);
+                    i += v.size();
+                  });
 
-    const int count = vir::count_if(vir::execution::simd, data, [](auto v) {
-                        if constexpr (std::is_floating_point_v<T>)
-                          return fmod(v, T(2)) == T(1);
-                        else
-                          return (v & T(1)) == T(1);
-                      });
-    COMPARE(count, int(V::size()) * 8 - 1);
+    i = 0;
+    std::for_each(std::execution::unseq, data.begin(), data.end(),
+                  [&i](auto v) {
+                    COMPARE(v, i);
+                    i += 1;
+                  });
+
+    int count = vir::count_if(exec_simd, data, [](auto v) {
+                  if constexpr (std::is_floating_point_v<T>)
+                    return fmod(v, T(2)) == T(1);
+                  else
+                    return (v & T(1)) == T(1);
+                });
+    COMPARE(count, int(data.size()) / 2);
+
+    count = std::count_if(exec_simd, data.begin(), data.end(), [](auto v) {
+              if constexpr (std::is_floating_point_v<T>)
+                return fmod(v, T(2)) == T(1);
+              else
+                return (v & T(1)) == T(1);
+            });
+    COMPARE(count, int(data.size()) / 2);
 #endif // VIR_HAVE_SIMD_EXECUTION
   }

--- a/testsuite/tests/for_each.cc
+++ b/testsuite/tests/for_each.cc
@@ -1,0 +1,35 @@
+// expensive: * [1-9] * *
+#include "bits/main.h"
+
+#include <numeric>
+#include <vector>
+
+#include <vir/simd_iota.h>
+#include <vir/simd_execution.h>
+
+template <typename V>
+  void
+  test()
+  {
+#if VIR_HAVE_SIMD_EXECUTION
+    using T = typename V::value_type;
+    std::vector<T> data;
+    data.resize(V::size() * 16 - 1);
+    std::iota(data.begin(), data.end(), T());
+
+    T i = 0;
+
+    vir::for_each(vir::execution::simd, data, [&i](auto v) {
+      COMPARE(v, vir::iota_v<decltype(v)> + i);
+      i += v.size();
+    });
+
+    const int count = vir::count_if(vir::execution::simd, data, [](auto v) {
+                        if constexpr (std::is_floating_point_v<T>)
+                          return fmod(v, T(2)) == T(1);
+                        else
+                          return (v & T(1)) == T(1);
+                      });
+    COMPARE(count, int(V::size()) * 8 - 1);
+#endif // VIR_HAVE_SIMD_EXECUTION
+  }

--- a/testsuite/tests/fpclassify.cc
+++ b/testsuite/tests/fpclassify.cc
@@ -30,7 +30,14 @@ template <typename F>
     return r;
   }
 
+#if VIR_HAVE_STD_SIMD
 #define NOFPEXCEPT(...) verify_no_fp_exceptions([&]() { return __VA_ARGS__; })
+#elif VIR_HAVE_VIR_SIMD
+// With the array-based simd implementation, GCC might auto-vectorize the classification functions,
+// hitting PR94413 (auto-vectorization of isfinite raises FP exception). Therefore, simply ignore FP
+// exceptions then.
+#define NOFPEXCEPT(...) [&]() { return __VA_ARGS__; }()
+#endif
 
 template <typename V>
   void

--- a/testsuite/tests/math_2arg.cc
+++ b/testsuite/tests/math_2arg.cc
@@ -63,6 +63,9 @@ template <typename V>
     vir::test::setFuzzyness<float>(0);
     vir::test::setFuzzyness<double>(0);
     vir::test::setFuzzyness<long double>(0);
+#if VIR_HAVE_VIR_SIMD
+    FloatExceptCompare::ignore = true; // GCC PR94413
+#endif
     test_values_2arg<V>(
       {
 #ifdef __STDC_IEC_559__

--- a/vir/detail.h
+++ b/vir/detail.h
@@ -112,6 +112,10 @@ namespace vir::detail
 
   using namespace vir::stdx;
 
+    /**
+     * Shortcut to determine the stdx::simd specialization with the most efficient ABI tag for the
+     * requested element type T and width N.
+     */
   template <typename T, int N>
     using deduced_simd = stdx::simd<T, stdx::simd_abi::deduce_t<T, N>>;
 

--- a/vir/simd.h
+++ b/vir/simd.h
@@ -24,6 +24,8 @@
 
 #if defined __cpp_lib_experimental_parallel_simd && __cpp_lib_experimental_parallel_simd >= 201803
 
+#define VIR_HAVE_STD_SIMD 1
+
 namespace vir::stdx
 {
   using namespace std::experimental::parallelism_v2;
@@ -42,6 +44,8 @@ namespace vir::stdx
 #include <tuple>
 #include <type_traits>
 #include <utility>
+
+#define VIR_HAVE_VIR_SIMD 1
 
 #ifdef VIR_SIMD_TS_DROPIN
 namespace std::experimental

--- a/vir/simd.h
+++ b/vir/simd.h
@@ -617,7 +617,8 @@ namespace vir::stdx
     {
     private:
       template <typename V, int M, size_t Parts>
-        friend std::enable_if_t<M == Parts * V::size() && is_simd_mask_v<V>, std::array<V, Parts>>
+        friend constexpr
+        std::enable_if_t<M == Parts * V::size() && is_simd_mask_v<V>, std::array<V, Parts>>
         split(const simd_mask<typename V::simd_type::value_type, simd_abi::fixed_size<M>>&);
 
       bool data[N];
@@ -1123,19 +1124,20 @@ namespace vir::stdx
 
       // load constructor
       template <typename U, typename Flags>
+        constexpr
         simd(const U* mem, Flags)
         : data(mem[0])
         {}
 
       // loads [simd.load]
       template <typename U, typename Flags>
-        void
+        constexpr void
         copy_from(const detail::Vectorizable<U>* mem, Flags)
         { data = mem[0]; }
 
       // stores [simd.store]
       template <typename U, typename Flags>
-        void
+        constexpr void
         copy_to(detail::Vectorizable<U>* mem, Flags) const
         { mem[0] = data; }
 
@@ -1373,11 +1375,13 @@ namespace vir::stdx
       friend class fixed_simd_int_base<T, N>;
 
       template <typename V, int M, size_t Parts>
-        friend std::enable_if_t<M == Parts * V::size() && is_simd_v<V>, std::array<V, Parts>>
+        friend constexpr
+        std::enable_if_t<M == Parts * V::size() && is_simd_v<V>, std::array<V, Parts>>
         split(const simd<typename V::value_type, simd_abi::fixed_size<M>>&);
 
       template <size_t... Sizes, typename U>
-        friend std::tuple<simd<U, simd_abi::deduce_t<U, int(Sizes)>>...>
+        friend constexpr
+        std::tuple<simd<U, simd_abi::deduce_t<U, int(Sizes)>>...>
         split(const simd<U, simd_abi::fixed_size<int((Sizes + ...))>>&);
 
       T data[N];
@@ -1674,6 +1678,7 @@ namespace vir::stdx
 
   // split(simd)
   template <typename V, int N, size_t Parts = N / V::size()>
+    constexpr
     std::enable_if_t<N == Parts * V::size() && is_simd_v<V>, std::array<V, Parts>>
     split(const simd<typename V::value_type, simd_abi::fixed_size<N>>& x)
     {
@@ -1686,6 +1691,7 @@ namespace vir::stdx
 
   // split(simd_mask)
   template <typename V, int N, size_t Parts = N / V::size()>
+    constexpr
     std::enable_if_t<N == Parts * V::size() && is_simd_mask_v<V>, std::array<V, Parts>>
     split(const simd_mask<typename V::simd_type::value_type, simd_abi::fixed_size<N>>& x)
     {
@@ -1698,6 +1704,7 @@ namespace vir::stdx
 
   // split<Sizes...>
   template <size_t... Sizes, typename T>
+    constexpr
     std::tuple<simd<T, simd_abi::deduce_t<T, int(Sizes)>>...>
     split(const simd<T, simd_abi::fixed_size<int((Sizes + ...))>>& x)
     {
@@ -1717,6 +1724,7 @@ namespace vir::stdx
 
   // split<V>(V)
   template <typename V>
+    constexpr
     std::enable_if_t<std::disjunction_v<is_simd<V>, is_simd_mask<V>>, std::array<V, 1>>
     split(const V& x)
     { return {x}; }
@@ -2134,7 +2142,7 @@ namespace vir::stdx
     }
 
   template <typename M, typename V, typename BinaryOperation = std::plus<>>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x,
         typename V::value_type identity_element,
         BinaryOperation binary_op)
@@ -2152,27 +2160,27 @@ namespace vir::stdx
     }
 
   template <typename M, typename V>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x, std::plus<> binary_op = {})
     { return reduce(x, 0, binary_op); }
 
   template <typename M, typename V>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x, std::multiplies<> binary_op)
     { return reduce(x, 1, binary_op); }
 
   template <typename M, typename V>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x, std::bit_and<> binary_op)
     { return reduce(x, ~typename V::value_type(), binary_op); }
 
   template <typename M, typename V>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x, std::bit_or<> binary_op)
     { return reduce(x, 0, binary_op); }
 
   template <typename M, typename V>
-    typename V::value_type
+    constexpr typename V::value_type
     reduce(const const_where_expression<M, V>& x, std::bit_xor<> binary_op)
     { return reduce(x, 0, binary_op); }
 

--- a/vir/simd_execution.h
+++ b/vir/simd_execution.h
@@ -1,0 +1,256 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright © 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH
+ *                  Matthias Kretz <m.kretz@gsi.de>
+ */
+
+#ifndef VIR_SIMD_EXECUTION_H_
+#define VIR_SIMD_EXECUTION_H_
+
+#include "simd_concepts.h"
+#include "simd_cvt.h"
+#include "simdize.h"
+
+#if VIR_HAVE_SIMD_CONCEPTS and VIR_HAVE_SIMDIZE and VIR_HAVE_SIMD_CVT
+#define VIR_HAVE_SIMD_EXECUTION 1
+
+#include <ranges>
+#include <cstdint>
+
+namespace vir
+{
+  namespace detail
+  {
+    template <typename T>
+      constexpr auto
+      data_or_ptr(T&& r) -> decltype(std::ranges::data(r))
+      { return std::ranges::data(r); }
+
+    template <typename T>
+      constexpr T*
+      data_or_ptr(T* ptr)
+      { return ptr; }
+
+    template <typename T>
+      constexpr const T*
+      data_or_ptr(const T* ptr)
+      { return ptr; }
+
+    // Invokes fun(V&) or fun(const V&) with V copied from r at offset i.
+    // If write_back is true, copy it back to r.
+    template <typename V, bool write_back, typename Flags, std::size_t... Is>
+      constexpr void
+      simd_load_and_invoke(auto&& fun, auto&& r, std::size_t i, Flags f, std::index_sequence<Is...>)
+      {
+        [&](auto... chunks) {
+          std::invoke(fun, chunks...);
+          if constexpr (write_back)
+            (chunks.copy_to(data_or_ptr(r) + i + (V::size() * Is), f), ...);
+        }(std::conditional_t<write_back, V, const V>(data_or_ptr(r) + i + (V::size() * Is), f)...);
+      }
+
+    template <class V, bool write_back, std::size_t max_bytes>
+      constexpr void
+      simd_for_each_prologue(auto&& fun, auto ptr, std::size_t to_process)
+      {
+        if (V::size() & to_process)
+          {
+            simd_load_and_invoke<V, write_back>(fun, ptr, 0, stdx::vector_aligned,
+                                                std::make_index_sequence<1>());
+            ptr += V::size();
+          }
+        if constexpr (V::size() * 2 * sizeof(typename V::value_type) < max_bytes)
+          {
+            simd_for_each_prologue<stdx::resize_simd_t<V::size() * 2, V>, write_back, max_bytes>(
+              fun, ptr, to_process);
+          }
+      }
+
+    template <class V0, bool write_back>
+      constexpr void
+      simd_for_each_epilogue(auto&& fun, auto&& rng, std::size_t i, auto f)
+      {
+        using V = stdx::resize_simd_t<V0::size() / 2, V0>;
+        if (i + V::size() <= std::ranges::size(rng))
+          {
+            simd_load_and_invoke<V, write_back>(fun, rng, i, f, std::make_index_sequence<1>());
+            i += V::size();
+          }
+        if constexpr (V::size() > 1)
+          simd_for_each_epilogue<V, write_back>(fun, rng, i, f);
+      }
+
+    struct simd_policy_prefer_aligned_t {};
+
+    inline constexpr simd_policy_prefer_aligned_t simd_policy_prefer_aligned{};
+
+    template <int N>
+      struct simd_policy_unroll_by_t
+      {};
+
+    template <int N>
+      inline constexpr simd_policy_unroll_by_t<N> simd_policy_unroll_by{};
+
+    template <typename T>
+      struct simd_policy_unroll_value
+      : std::integral_constant<int, 0>
+      {};
+
+    template <int N>
+      struct simd_policy_unroll_value<const simd_policy_unroll_by_t<N>>
+      : std::integral_constant<int, N>
+      {};
+
+    template <int N>
+      struct simd_policy_size_t
+      {};
+
+    template <int N>
+      inline constexpr simd_policy_size_t<N> simd_policy_size{};
+
+    template <typename T>
+      struct simd_policy_size_value
+      : std::integral_constant<int, 0>
+      {};
+
+    template <int N>
+      struct simd_policy_size_value<const simd_policy_size_t<N>>
+      : std::integral_constant<int, N>
+      {};
+
+    template <typename T>
+      struct is_simd_policy
+      : std::false_type
+      {};
+
+  } // namespace detail
+
+  namespace execution
+  {
+    template <auto... Options>
+      struct simd_policy
+      {
+        static constexpr bool _prefers_aligned
+          = (false or ... or std::same_as<decltype(Options),
+                                          const detail::simd_policy_prefer_aligned_t>);
+
+        static constexpr int _unroll_by
+          = (0 + ... + detail::simd_policy_unroll_value<decltype(Options)>::value);
+
+        static constexpr int _size
+          = (0 + ... + detail::simd_policy_size_value<decltype(Options)>::value);
+
+        static constexpr simd_policy<Options..., detail::simd_policy_prefer_aligned>
+        prefer_aligned() requires(not _prefers_aligned)
+        { return {}; }
+
+        template <int N>
+          static constexpr simd_policy<Options..., detail::simd_policy_unroll_by<N>>
+          unroll_by() requires(_unroll_by == 0)
+          {
+            static_assert(N > 1);
+            return {};
+          }
+
+        template <int N>
+          static constexpr simd_policy<Options..., detail::simd_policy_size<N>>
+          prefer_size() requires(_size == 0)
+          {
+            static_assert(N > 0);
+            return {};
+          };
+      };
+
+    inline constexpr simd_policy<> simd {};
+  } // namespace execution
+
+  namespace detail
+  {
+    template <auto... Options>
+      struct is_simd_policy<execution::simd_policy<Options...>>
+      : std::true_type
+      {};
+  }
+
+  template <typename ExecutionPolicy, std::ranges::contiguous_range R, typename F>
+    requires (detail::is_simd_policy<ExecutionPolicy>::value
+                and requires
+             {
+               typename vir::simdize<std::ranges::range_value_t<R>>;
+             })
+    constexpr void
+    for_each(ExecutionPolicy, R&& rng, F&& fun)
+    {
+      using T = std::ranges::range_value_t<R>;
+      using V = vir::simdize<T, ExecutionPolicy::_size>;
+      constexpr bool write_back = std::ranges::output_range<R, T>
+                                    and std::invocable<F, V&> and not std::invocable<F, V&&>;
+      std::size_t i = 0;
+      constexpr std::conditional_t<ExecutionPolicy::_prefers_aligned, stdx::vector_aligned_tag,
+                                   stdx::element_aligned_tag> flags{};
+      if constexpr (ExecutionPolicy::_prefers_aligned)
+        {
+          const auto misaligned_by = reinterpret_cast<std::uintptr_t>(std::ranges::data(rng))
+                                       % stdx::memory_alignment_v<V>;
+          if (misaligned_by != 0)
+            {
+              const auto to_process = stdx::memory_alignment_v<V> - misaligned_by;
+              detail::simd_for_each_prologue<stdx::resize_simd_t<1, V>, write_back,
+                                             stdx::memory_alignment_v<V>>(
+                fun, std::ranges::data(rng), to_process);
+              i = to_process;
+            }
+        }
+
+      if constexpr (ExecutionPolicy::_unroll_by > 1)
+        {
+          for (; i + V::size() * ExecutionPolicy::_unroll_by <= std::ranges::size(rng);
+               i += V::size() * ExecutionPolicy::_unroll_by)
+            {
+              detail::simd_load_and_invoke<V, write_back>(
+                fun, rng, i, flags, std::make_index_sequence<ExecutionPolicy::_unroll_by>());
+            }
+        }
+
+      for (; i + V::size() <= std::ranges::size(rng); i += V::size())
+        detail::simd_load_and_invoke<V, write_back>(fun, rng, i, flags,
+                                                    std::make_index_sequence<1>());
+
+      if constexpr (V::size() > 1)
+        detail::simd_for_each_epilogue<V, write_back>(fun, rng, i, flags);
+    }
+
+  template <typename ExecutionPolicy, std::ranges::contiguous_range R, typename F>
+    requires detail::is_simd_policy<ExecutionPolicy>::value
+    constexpr int
+    count_if(ExecutionPolicy pol, R const& v, F&& fun)
+    {
+      using T = std::ranges::range_value_t<R>;
+      using TV = vir::simdize<T, ExecutionPolicy::_size>;
+      using IV = detail::deduced_simd<int, TV::size()>;
+      int count = 0;
+      IV countv = 0;
+      vir::for_each(pol, v, [&](auto... x) {
+#if __cpp_lib_experimental_parallel_simd >= 201803
+        if (std::is_constant_evaluated())
+          count += (popcount(fun(x)) + ...);
+        else
+#endif
+          if constexpr (sizeof...(x) == 1)
+          {
+            if constexpr ((x.size(), ...) == countv.size())
+              ++where(vir::cvt(fun(x...)), countv);
+            else
+              count += popcount(fun(x...));
+          }
+        else
+          {
+            ((++where(vir::cvt(fun(x)), countv)), ...);
+          }
+      });
+      return count + reduce(countv);
+    }
+}  // namespace vir
+#endif // VIR_HAVE_SIMD_CONCEPTS
+#endif // VIR_SIMD_EXECUTION_H_
+
+// vim: et cc=101 tw=100 sw=2 ts=8

--- a/vir/simdize.h
+++ b/vir/simdize.h
@@ -14,6 +14,7 @@
 #include <tuple>
 #include <iterator>
 #include "simd.h"
+#include "detail.h"
 #include "simd_concepts.h"
 
 namespace vir
@@ -48,13 +49,6 @@ namespace vir
 
   namespace detail
   {
-    /**
-     * Shortcut to determine the stdx::simd specialization with the most efficient ABI tag for the
-     * requested element type T and width N.
-     */
-    template <typename T, std::size_t N>
-      using deduced_simd = stdx::simd<T, stdx::simd_abi::deduce_t<T, N>>;
-
     template <typename T, std::size_t N>
       struct simdize_impl;
 

--- a/vir/test.cpp
+++ b/vir/test.cpp
@@ -308,8 +308,13 @@ namespace algorithms_tests
 {
   static_assert(vir::execution::simd._size == 0);
   static_assert(vir::execution::simd.prefer_size<4>()._size == 4);
+  static_assert(vir::execution::simd.prefer_aligned().prefer_size<4>()._size == 4);
   static_assert(vir::execution::simd._unroll_by == 0);
   static_assert(vir::execution::simd.unroll_by<3>()._unroll_by == 3);
+  static_assert(vir::execution::simd.prefer_aligned().unroll_by<5>()._unroll_by == 5);
+  static_assert(vir::execution::simd._prefers_aligned == false);
+  static_assert(vir::execution::simd.prefer_aligned()._prefers_aligned == true);
+  static_assert(vir::execution::simd.prefer_size<4>().prefer_aligned()._prefers_aligned == true);
   static_assert([] {
     std::array input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     vir::for_each(vir::execution::simd, input, [](auto& v) {
@@ -324,7 +329,7 @@ namespace algorithms_tests
     });
     if (input != std::array{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21})
       return false;
-    vir::for_each(vir::execution::simd, input, [](auto v) {
+    vir::for_each(vir::execution::simd.prefer_aligned(), input, [](auto v) {
       v += 2;
     });
     if (input != std::array{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21})

--- a/vir/test.cpp
+++ b/vir/test.cpp
@@ -315,6 +315,9 @@ namespace algorithms_tests
   static_assert(vir::execution::simd._prefers_aligned == false);
   static_assert(vir::execution::simd.prefer_aligned()._prefers_aligned == true);
   static_assert(vir::execution::simd.prefer_size<4>().prefer_aligned()._prefers_aligned == true);
+  static_assert(vir::execution::simd._auto_prologue == false);
+  static_assert(vir::execution::simd.auto_prologue()._auto_prologue == true);
+  static_assert(vir::execution::simd.prefer_size<4>().auto_prologue()._auto_prologue == true);
   static_assert([] {
     std::array input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     vir::for_each(vir::execution::simd, input, [](auto& v) {


### PR DESCRIPTION
The goal of this PR is to add an execution policy similar to `std::execution::par` etc. that can be used with standard algorithms. While overloading of functions is `std` is UB ([[namespace.std] p1](https://eel.is/c++draft/constraints#namespace.std-1): "Unless otherwise specified, the behavior of a C++ program is undefined if it adds declarations or definitions to namespace std or to a namespace within namespace std."), technically we can overload the algorithms in `std` using a program-defined type for disambiguation. For users who want to avoid the theoretical UB or want to use a range overload we reproduce the `std` algorithms in the `vir` namespace.

The `simd` execution policy can make use of several tuning knobs, which sets it apart from the other policies (for now; std-execution P2300 will likely lead to similar facilities for `par`). [P0350](https://wg21.link/p0350)