### PR TITLE
Refactor vir::cvt to work with C++17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,14 @@ check-extensions: check-extensions-stdlib check-extensions-fallback
 check-extensions-stdlib:
 	@echo "$(std): test extensions ($(CXXFLAGS))"
 	@$(CXX) -O2 -std=$(std) -Wall -Wextra $(CXXFLAGS) -S vir/test.cpp -o test.S
+	@echo "gnu++17: test extensions ($(CXXFLAGS))"
+	@$(CXX) -O2 -std=gnu++17 -Wall -Wextra $(CXXFLAGS) -S vir/test.cpp -o test17.S
 
 check-extensions-fallback:
 	@echo "$(std): test extensions ($(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD)"
 	@$(CXX) -O2 -std=$(std) -Wall -Wextra $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -S vir/test.cpp -o test.S
+	@echo "gnu++17: test extensions ($(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD)"
+	@$(CXX) -O2 -std=gnu++17 -Wall -Wextra $(CXXFLAGS) -DVIR_DISABLE_STDX_SIMD -S vir/test.cpp -o test17.S
 
 check-constexpr_wrapper:
 	@echo "gnu++2a: test constexpr_wrapper ($(CXXFLAGS))"

--- a/vir/simd_cvt.h
+++ b/vir/simd_cvt.h
@@ -7,11 +7,26 @@
 #define VIR_SIMD_CVT_H_
 
 #include "simd_concepts.h"
-#if VIR_HAVE_SIMD_CONCEPTS
 #define VIR_HAVE_SIMD_CVT 1
 
 namespace vir
 {
+#if not VIR_HAVE_SIMD_CONCEPTS
+  namespace detail
+  {
+    template <typename From, typename To, typename = void>
+      struct can_static_simd_cast
+      : std::false_type
+      {};
+
+    template <typename From, typename To>
+      struct can_static_simd_cast<From, To, std::void_t<decltype(stdx::static_simd_cast<To>(
+                                                                   std::declval<const From&>()))>>
+      : std::is_same<decltype(stdx::static_simd_cast<To>(std::declval<const From&>())), To>
+      {};
+  }
+#endif
+
   template <typename T>
     class cvt
     {
@@ -25,15 +40,21 @@ namespace vir
 
       cvt(const cvt&) = delete;
 
+#if VIR_HAVE_SIMD_CONCEPTS
       template <typename U>
 	requires std::convertible_to<T, U> or requires(const T&x)
 	{
 	  { stdx::static_simd_cast<U>(x) } -> std::same_as<U>;
 	}
+#else
+      template <typename U, typename = std::enable_if_t<
+                                         std::disjunction_v<std::is_convertible<T, U>,
+                                                            detail::can_static_simd_cast<T, U>>>>
+#endif
 	constexpr
 	operator U() const
 	{
-	  if constexpr (std::convertible_to<T, U>)
+	  if constexpr (std::is_convertible_v<T, U>)
 	    return ref;
 	  else
 	    return stdx::static_simd_cast<U>(ref);
@@ -41,6 +62,5 @@ namespace vir
     };
 }
 
-#endif  // VIR_HAVE_SIMD_CONCEPTS
 #endif  // VIR_SIMD_CVT_H_
-// vim: noet cc=101 tw=100 sw=2 ts=8
+// vim: et cc=101 tw=100 sw=2 ts=8

--- a/vir/struct_reflect.h
+++ b/vir/struct_reflect.h
@@ -12,6 +12,7 @@
 
 #if defined DOXYGEN \
     or (defined __cpp_structured_bindings && defined __cpp_concepts && __cpp_concepts >= 201907)
+#if !__cpp_lib_tuple_like || !defined __clang__ || __clang_major__ != 17
 #define VIR_HAVE_STRUCT_REFLECT 1
 #include <utility>
 #include <tuple>
@@ -531,6 +532,7 @@ namespace vir
 
 }  // namespace vir
 
+#endif // work around broken Clang
 #endif // structured bindings & concepts
 #endif // VIR_STRUCT_SIZE_H_
 

--- a/vir/test.cpp
+++ b/vir/test.cpp
@@ -462,6 +462,7 @@ namespace test_simdize
   static_assert(vir::vectorizable_struct<T>);
 }
 
+#if VIR_SIMD_HAVE_CONSTEXPR_API
 static_assert([] {
   vir::simdize<Point> p1 = Point{1.f, 1.f, 1.f};
   vir::simdize<Point> p2 {V<float>([](short i) { return i; }),
@@ -493,6 +494,7 @@ static_assert([] {
   }
   return true;
 }());
+#endif
 
 struct Line
 {
@@ -507,6 +509,7 @@ static_assert(std::same_as<vir::as_tuple_t<Line>,
 static_assert(std::same_as<vir::simdize<Line>,
 			   vir::simd_tuple<Line, V<float>::size()>>);
 
+#if VIR_SIMD_HAVE_CONSTEXPR_API
 #if VIR_HAVE_SIMD_IOTA
 constexpr vir::simdize<Point> point{vir::iota_v<V<float>>, 2.f, 3.f};
 static_assert(point[0].x == 0.f);
@@ -547,6 +550,7 @@ static_assert([] {
   v.copy_to(data.begin());
   return data == std::array<Point, 5> {Point{1, 1, 0}, {1, 2, 0}, {1, 3, 0}, {0, 0, 0}, {0, 0, 0}};
 }());
+#endif // VIR_SIMD_HAVE_CONSTEXPR_API
 
 #endif  // VIR_HAVE_SIMDIZE
 #endif  // VIR_HAVE_STRUCT_REFLECT
@@ -578,6 +582,7 @@ namespace algorithms_tests
   static_assert(vir::execution::simd._auto_prologue == false);
   static_assert(vir::execution::simd.auto_prologue()._auto_prologue == true);
   static_assert(vir::execution::simd.prefer_size<4>().auto_prologue()._auto_prologue == true);
+#if VIR_SIMD_HAVE_CONSTEXPR_API
   static_assert([] {
     std::array input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     vir::for_each(vir::execution::simd, input, [](auto& v) {
@@ -628,6 +633,7 @@ namespace algorithms_tests
     int r = std::transform_reduce(vir::execution::simd, a1.begin(), a1.end(), a2.begin(), 0);
     return r == 2470;
   }());
+#endif // VIR_SIMD_HAVE_CONSTEXPR_API
 }
 #endif  // VIR_HAVE_SIMD_EXECUTION
 

--- a/vir/test.cpp
+++ b/vir/test.cpp
@@ -101,10 +101,17 @@ namespace
 		}(V<int>(1)), 1.f));
 #endif
   // simd_mask:
-  static_assert(std::same_as<decltype(cvt(RV<int, float>(2) == 2) == (V<float>(1) == 1.f)),
-			     typename V<float>::mask_type>);
+  static_assert(std::is_same_v<decltype(cvt(RV<int, float>(2) == 2) == (V<float>(1) == 1.f)),
+			       typename V<float>::mask_type>);
   // arithmetic:
   static_assert(float(cvt(1)) == 1.f);
+
+  static_assert(std::is_convertible_v<cvt<V<float>>, RV<int, float>>);
+  static_assert(std::is_convertible_v<cvt<V<char>>, RV<int, char>>);
+  static_assert(not std::is_convertible_v<cvt<V<float>>, int>);
+  static_assert(std::is_convertible_v<cvt<float>, int>);
+  static_assert(std::is_convertible_v<cvt<int>, V<double>>);
+  static_assert(std::is_convertible_v<cvt<V<float>::mask_type>, RV<short, float>::mask_type>);
 }
 #endif // VIR_HAVE_SIMD_CVT
 


### PR DESCRIPTION
Fixes: gh-45

ChangeLog:

	* Makefile: Always test with gnu++17.
	* vir/simd_cvt.h: Remove hard dependency on VIR_HAVE_SIMD_CONCEPTS.
	* vir/test.cpp: Add is_convertible_v tests for vir::cvt.