### PR TITLE
Add RPM packaging template

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,19 @@
+# dist directory
+
+Definitions for distribution tools.
+
+## RPM spec
+
+Currently, there's an `rpkg` spec in here. If you'd like to use it locally, install `rpkg` on your fedoraoid of choice, and run
+
+```shell
+cd path/to/vir-simd
+rpkg local --spec dist/vir-simd.spec
+```
+
+The more useful thing that can be done with this is that you can create a
+[COPR](https://copr.fedorainfracloud.org), add a package of source type "SCM",
+point it to your fork of vir-simd, specify "dist" as subdirectory, and use it
+to build packages automatically; there's also webhooks integration, if you want
+the package to be automatically rebuild on source repo forge events (usually,
+when pushing a new tag).

--- a/dist/vir-simd.spec
+++ b/dist/vir-simd.spec
@@ -1,0 +1,51 @@
+# header-only library
+%global debug_package %{nil}
+Version:        {{{ git_repo_version }}}
+%forgemeta
+Name:           vir-simd
+Release:        1%{?dist}
+Summary:        Parallelism TS 2 extensions and simd fallback implementation
+
+License:        LGPL-3.0+
+URL:            https://github.com/mattkretz/vir-simd/
+VCS:            {{{ git_repo_vcs }}}
+Source:         {{{ git_repo_pack }}}
+BuildRequires:  make
+BuildRequires:  gcc-c++
+
+
+%description
+vir-simd aims to provide a fallback std::experimental::simd (Parallelism TS 2)
+implementation with additional features. Not every user can rely on GCC 11+ and
+its standard library to be present on all target systems. Therefore, the header
+vir/simd.h provides a fallback implementation of the TS specification that only
+implements the scalar and fixed_size<N> ABI tags. Thus, your code can still
+compile and run correctly, even if it is missing the performance gains a proper
+implementation provides.
+
+%package devel
+Summary: Development files for %{name}
+%description devel
+The %{name}-devel package contains development files for %{name}.
+
+%prep
+{{{ git_repo_setup_macro }}}
+
+%build
+
+%install
+%make_install includedir=%{buildroot}%{_includedir}
+
+
+%check
+# Currently fails upstream on Linux. Not worth chasing here.
+#make testsuite-O2
+
+%files devel
+%license LICENSE
+%{_includedir}/vir/*.h
+
+
+%changelog
+
+{{{ git_repo_changelog }}}


### PR DESCRIPTION
this adds an `rpkg` spec-template, to enable users to quickly build a Fedora/Redhat/… package.

```shell
cd path/to/vir-simd
rpkg local --spec dist/vir-simd.spec
```

is what it takes to build things locally; but the real power lies in the fact that it enables automated builds from git changes on forges; concretely, this underpins https://copr.fedorainfracloud.org/coprs/marcusmueller/vir-simd/ , so I can now install vir-simd as proper header-only library dependency (instead of having to build it as a submodule).