### PR TITLE
Bug: add exp, exp2, expm1 and cbrt to the fallback simd

### DIFF
--- a/testsuite/tests/exponential.cc
+++ b/testsuite/tests/exponential.cc
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH
+ *                  Matthias Kretz <m.kretz@gsi.de>
+ * Copyright © 2026 The Regents of the University of California,
+ *                  through Lawrence Berkeley National Laboratory
+ *                  (subject to receipt of any required approvals from
+ *                  the U.S. Dept. of Energy). All rights reserved.
+ *                  Axel Huebl <axelhuebl@lbl.gov>
+ */
+
+// only: float|double|ldouble * * *
+// expensive: * [1-9] * *
+#include "bits/main.h"
+
+template <typename V>
+  void
+  test()
+  {
+    vir::test::setFuzzyness<float>(1);
+    vir::test::setFuzzyness<double>(1);
+
+    using T = typename V::value_type;
+    constexpr T nan = vir::quiet_NaN_v<T>;
+    constexpr T inf = vir::infinity_v<T>;
+    constexpr T denorm_min = vir::denorm_min_v<T>;
+    constexpr T norm_min = vir::norm_min_v<T>;
+    constexpr T min = vir::finite_min_v<T>;
+    constexpr T max = vir::finite_max_v<T>;
+
+    // The exponentials, on a range that reaches the overflow and underflow
+    // edges from both sides. expm1 is the reason for the small values: it
+    // exists precisely to be accurate where exp(x) - 1 cancels.
+    test_values<V>({0,
+		    1,
+		    -1,
+		    2,
+		    -2,
+		    10,
+		    -10,
+		    100,
+		    -100,
+#ifdef __STDC_IEC_559__
+		    nan,
+		    inf,
+		    -inf,
+		    denorm_min,
+		    -denorm_min,
+		    norm_min,
+		    -norm_min,
+		    norm_min / 3,
+		    -norm_min / 3,
+		    -T(),
+		    T(),
+		    min,
+		    max,
+#endif
+		    T(0.5),
+		    T(-0.5)},
+		   {10000, T(-100), T(100)},
+		   MAKE_TESTER(exp), MAKE_TESTER(exp2), MAKE_TESTER(expm1));
+
+    // cbrt takes the whole range, unlike the exponentials, and is defined for
+    // negative arguments where sqrt is not.
+    test_values<V>({0,
+		    1,
+		    -1,
+		    8,
+		    -8,
+		    27,
+		    -27,
+#ifdef __STDC_IEC_559__
+		    nan,
+		    inf,
+		    -inf,
+		    denorm_min,
+		    -denorm_min,
+		    norm_min,
+		    -norm_min,
+		    -T(),
+		    T(),
+		    min,
+		    max,
+#endif
+		    T(0.5),
+		    T(-0.5)},
+		   {10000,
+#ifdef __STDC_IEC_559__
+		    min / 2,
+#else
+		    norm_min,
+#endif
+		    max / 2},
+		   MAKE_TESTER(cbrt));
+  }

--- a/vir/simd.h
+++ b/vir/simd.h
@@ -2595,6 +2595,12 @@ namespace vir::stdx
   SIMD_MATH_1ARG(log2, simd)
   SIMD_MATH_1ARG(logb, simd)
 
+  // exponentials and roots
+  SIMD_MATH_1ARG(exp, simd)
+  SIMD_MATH_1ARG(exp2, simd)
+  SIMD_MATH_1ARG(expm1, simd)
+  SIMD_MATH_1ARG(cbrt, simd)
+
 #undef SIMD_MATH_1ARG
 #undef SIMD_MATH_1ARG_FIXED
 #undef SIMD_MATH_2ARG


### PR DESCRIPTION
`vir::stdx`'s own simd, used where the standard library has no `<experimental/simd>`, implements most of the Parallelism TS math set but not `exp`, `exp2`, `expm1` or `cbrt`. `sin`, `log`, `log2`, `erf`, `pow` and `hypot` are all there, so the gap is easy to miss until portable code calls one of the four.

It showed up building AMReX on macOS, where Apple Clang and libc++ select this simd:

```
error: no member named 'exp' in namespace 'vir::stdx'
```

for those four and nothing else. Added with the same `SIMD_MATH_1ARG` as their neighbours, so they are per-lane like the rest of this fallback.

Second commit adds `exponential.cc`, mirroring `logarithm.cc` — these four had no test, which is part of why the hole went unnoticed. It does not compile without the first commit.
