### PR TITLE
CI: pin the test ISA below AVX-512

### DIFF
--- a/.github/workflows/Clang.yml
+++ b/.github/workflows/Clang.yml
@@ -53,7 +53,15 @@ jobs:
           path: vc-testdata
 
       - name: Run test suite
-        run: cd vir-simd && make check DRIVEROPTS=-vvf
+        # Pinned below AVX-512 on purpose. libstdc++'s <experimental/simd> does
+        # not compile under Clang for the AVX-512 mask ABIs: _S_to_bits asserts
+        # is_same_v<_Tp, __int_for_sizeof_t<_Tp>>, and for _Tp = long long that
+        # is false there, so simd<double, _VecBltnBtmsk<N>>::operator== fails to
+        # instantiate. The testsuite otherwise builds with -march=native, so
+        # this job started failing when the runner fleet moved to AVX-512
+        # capable hardware, with nothing in this repository having changed.
+        # GCC compiles the same code, and keeps -march=native.
+        run: cd vir-simd && make check DRIVEROPTS=-vvf testflags=-march=x86-64-v3
 
   clang-libcxx:
     strategy:

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -65,4 +65,11 @@ jobs:
           diff -r $HOME/vir-simd-cmake/include $HOME/vir-simd-make/include && echo "cmake and make installations match ✅"
 
       - name: Run test suite
-        run: cd vir-simd && make check DRIVEROPTS=-vvf
+        # Pinned below AVX-512, as the Clang jobs are, though for a
+        # different reason. simd_abi::max_fixed_size<int> is 32, so on
+        # AVX-512 a 64-lane simd<char> has no matching int ABI: transform
+        # widening char to int asks for simd<int, fixed_size<64>>, which
+        # libstdc++ gives a deleted destructor. The testsuite otherwise
+        # builds -march=native, and the runner fleet is mixed, so whether a
+        # job saw this came down to which machine it landed on.
+        run: cd vir-simd && make check DRIVEROPTS=-vvf testflags=-march=x86-64-v3


### PR DESCRIPTION
The Clang jobs that use libstdc++ went red without a commit to blame.

libstdc++'s `<experimental/simd>` does not compile under Clang for the AVX-512 mask ABIs: `_MaskImplX86Mixin::_S_to_bits` asserts `is_same_v<_Tp, __int_for_sizeof_t<_Tp>>`, and under Clang `__int_for_sizeof_t<long long>` is `long`, so `simd<double, _VecBltnBtmsk<N>>::operator==` never instantiates:

```
simd_x86.h:4232: static assertion failed due to requirement 'is_same_v<long long, long>'
```

The testsuite builds with `-march=native`, so what these jobs cover depends on the runner's CPU. That changed: the fleet moved to also include AVX-512 capable hardware (randomly assigned from Azure), `-march=native` started selecting the mask ABIs, and the jobs went red on an unchanged tree.

Pinning them to `x86-64-v3` (supported by every x86-64 runner) stops Clang coverage depending on the runner. GCC compiles the same code fine and keeps `-march=native`, so AVX-512 stays covered there. `clang-libcxx` is untouched — with libc++ there is no `<experimental/simd>`, so vir-simd uses its own and never reaches this code.

The bug is libstdc++'s; this only stops it deciding whether CI is green.
GCC's vector-compare on double yields long elements, Clang's yields long long. libstdc++'s `__int_for_sizeof_t<8>` is int64_t = long on LP64.

Reproduced locally with Clang 18 + libstdc++ 13: fails at `-march=skylake-avx512`, `sapphirerapids`, `znver4` and `x86-64-v4`, passes at `x86-64-v3`. GCC 13/14 pass at `-march=skylake-avx512`.

---

**Update: the GCC jobs need the same pin, for a different reason.**

`simd_abi::max_fixed_size<int>` is 32, so an AVX-512 `simd<char>` (64 lanes) has no matching `int` ABI. Two tests walk into that:

| test | what it asks for |
|---|---|
| `for_each.cc` | `count_if` needs `deduced_simd<int, 64>`, which has no `type` |
| `transform.cc` | widening `char`→`int` asks for `simd<int, fixed_size<64>>`, whose destructor libstdc++ deletes |

`transform.cc` fails identically on GCC 11, 12 and 13, so it is not one version's bug. Because the fleet is mixed, whether a job saw any of this came down to which machine it landed on — GCC 11 passed one run and failed the next on an unchanged tree.

The AVX-512 coverage this gives up was never dependable: where a runner did offer it, these tests did not compile. Fixing the algorithms is worth doing separately (`count_if` is #56); this is only about CI reporting something reproducible.

Validated on a fork: with the Clang pin, the Clang matrix goes green (https://github.com/ax3l/vir-simd/pull/3).