### PR TITLE
[WIP] Bug in `count_if` for AVX-512: fall back to popcount where the int ABI does not exist

### DIFF
--- a/vir/simd_execution.h
+++ b/vir/simd_execution.h
@@ -1503,28 +1503,45 @@ case0:
     {
       using T = std::iter_value_t<It>;
       using TV = vir::simdize<T, ExecutionPolicy::_size>;
-      using IV = detail::deduced_simd<int, TV::size()>;
       int count = 0;
-      IV countv = 0;
-      vir::for_each(pol, first, last, [&](auto... x) VIR_LAMBDA_ALWAYS_INLINE {
+
+      /* Counting per lane needs an int simd with one lane per element, and that
+       * ABI stops existing once TV has more lanes than simd_abi::max_fixed_size
+       * <int> allows: simd<char> is 64 lanes wide on AVX-512, where deduce<int,
+       * 64> has no type. Fall back to counting the bits of each mask, which is
+       * what the size-mismatched case below does anyway.
+       */
+      if constexpr (not requires { typename detail::deduced_simd<int, TV::size()>; })
+        {
+          vir::for_each(pol, first, last, [&](auto... x) VIR_LAMBDA_ALWAYS_INLINE {
+            count += (popcount(pred(x)) + ...);
+          });
+          return count;
+        }
+      else
+        {
+          using IV = detail::deduced_simd<int, TV::size()>;
+          IV countv = 0;
+          vir::for_each(pol, first, last, [&](auto... x) VIR_LAMBDA_ALWAYS_INLINE {
 #if __cpp_lib_experimental_parallel_simd >= 201803
-        if (std::is_constant_evaluated())
-          count += (popcount(pred(x)) + ...);
-        else
-#endif
-          if constexpr (sizeof...(x) == 1)
-          {
-            if constexpr ((x.size(), ...) == countv.size())
-              ++where(vir::cvt(pred(x...)), countv);
+            if (std::is_constant_evaluated())
+              count += (popcount(pred(x)) + ...);
             else
-              count += popcount(pred(x...));
-          }
-        else
-          {
-            ((++where(vir::cvt(pred(x)), countv)), ...);
-          }
-      });
-      return count + reduce(countv);
+#endif
+              if constexpr (sizeof...(x) == 1)
+              {
+                if constexpr ((x.size(), ...) == countv.size())
+                  ++where(vir::cvt(pred(x...)), countv);
+                else
+                  count += popcount(pred(x...));
+              }
+            else
+              {
+                ((++where(vir::cvt(pred(x)), countv)), ...);
+              }
+          });
+          return count + reduce(countv);
+        }
     }
 
   /// Count the elements in the input range matching \p pred (range overload)


### PR DESCRIPTION
> **Heads up:** this is a Claude-written attempt at fixing the red GCC jobs. It is tested as described below, but please review it as such — the fallback changes how `count_if` accumulates on the affected configurations.

`count_if` accumulates one `int` per element:

```cpp
using IV = detail::deduced_simd<int, TV::size()>;
```

which needs an `int` simd with as many lanes as the value type's. That ABI stops existing once `TV` is wider than `simd_abi::max_fixed_size<int>` allows — `simd<char>` is 64 lanes on AVX-512 and `max_fixed_size<int>` is 32, so `deduce<int, 64>` has no `type` and the function fails to substitute:

```
simd_execution.h:1506: error: no type named 'type' in 'struct simd_abi::deduce<int, 64>'
```

This reaches anyone calling `count_if` over a `char` range on an AVX-512 host. It also turned CI red on GCC 13 and 14 with nothing in the tree having changed: the testsuite builds `-march=native`, and the runner fleet moved to AVX-512 capable hardware.

Counting the bits of each mask instead when that ABI is unavailable. `count_if` already does exactly this where the lane counts do not line up, so this reuses the existing fallback rather than adding a second way to count.

### Testing

- GCC 13, `-march=skylake-avx512`: `for_each.cc` compiles clean for `char`, `short`, `int`, `float` and `double`. Before, `char` failed.
- Correctness of the fallback checked by forcing it for every case (`if constexpr (true)`) at the native ISA so it actually executes: `for_each` passes 32/32.
- Unforced, the ext testsuite passes 96/96, so the per-lane accumulator is unchanged where it exists.

Only `char` is affected at AVX-512. Separate from #55, which pins the Clang jobs below AVX-512 for an unrelated libstdc++ bug.
